### PR TITLE
Phase 1: CSS完全クリーンアップ

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -56,215 +56,14 @@
   display: block;
 }
 
-.stamp-overlay {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  pointer-events: none;
-}
-
-.stamp-position {
-  position: absolute;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-direction: column;
-}
 
 
 
-// 月・年・ユーザー名オーバーレイ
-.month-year-overlay {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  pointer-events: none;
-  z-index: 1;
-}
-
-.calendar-year {
-  position: absolute;
-  top: 8.5%;
-  left: 75%;
-  transform: translateX(-50%);
-  font-size: 1.2rem;
-  font-weight: bold;
-  color: #2c3e50;
-  text-shadow: 1px 1px 2px rgba(255, 255, 255, 0.8);
-}
-
-.calendar-month-number {
-  position: absolute;
-  top: 8.5%;
-  left: 85%;
-  transform: translateX(-50%);
-  font-size: 1.8rem;
-  font-weight: bold;
-  color: #e74c3c;
-  text-shadow: 1px 1px 2px rgba(255, 255, 255, 0.8);
-}
-
-.calendar-month-text {
-  position: absolute;
-  top: 8.5%;
-  left: 92%;
-  transform: translateX(-50%);
-  font-size: 1.2rem;
-  font-weight: bold;
-  color: #2c3e50;
-  text-shadow: 1px 1px 2px rgba(255, 255, 255, 0.8);
-}
-
-.calendar-user-name {
-  position: absolute;
-  top: 13%;
-  left: 83%;
-  transform: translateX(-50%);
-  font-size: 0.9rem;
-  font-weight: 600;
-  color: #34495e;
-  text-shadow: 1px 1px 2px rgba(255, 255, 255, 0.8);
-  max-width: 120px;
-  text-align: center;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-// 各日付の位置座標（5週間×7日のグリッド）
-// 画像内のカレンダー部分に対応する位置を計算
-.stamp-position {
-  // 基準となる位置計算
-  // 週インデックス（0-4）と日インデックス（0-6）から位置を算出
-  
-  // 1-4週目をほんの少し下に微調整
-  &[data-week="0"] {
-    &[data-day="0"] { top: 41.5% !important; left: 11% !important; } // 日
-    &[data-day="1"] { top: 41.5% !important; left: 24% !important; } // 月
-    &[data-day="2"] { top: 41.5% !important; left: 37% !important; } // 火
-    &[data-day="3"] { top: 41.5% !important; left: 50% !important; } // 水
-    &[data-day="4"] { top: 41.5% !important; left: 63% !important; } // 木
-    &[data-day="5"] { top: 41.5% !important; left: 76% !important; } // 金
-    &[data-day="6"] { top: 41.5% !important; left: 89% !important; }  // 土
-  }
-  
-  // 2週目
-  &[data-week="1"] {
-    &[data-day="0"] { top: 50.5% !important; left: 11% !important; }
-    &[data-day="1"] { top: 50.5% !important; left: 24% !important; }
-    &[data-day="2"] { top: 50.5% !important; left: 37% !important; }
-    &[data-day="3"] { top: 50.5% !important; left: 50% !important; }
-    &[data-day="4"] { top: 50.5% !important; left: 63% !important; }
-    &[data-day="5"] { top: 50.5% !important; left: 76% !important; }
-    &[data-day="6"] { top: 50.5% !important; left: 89% !important; }
-  }
-  
-  // 3週目
-  &[data-week="2"] {
-    &[data-day="0"] { top: 59.5% !important; left: 11% !important; }
-    &[data-day="1"] { top: 59.5% !important; left: 24% !important; }
-    &[data-day="2"] { top: 59.5% !important; left: 37% !important; }
-    &[data-day="3"] { top: 59.5% !important; left: 50% !important; }
-    &[data-day="4"] { top: 59.5% !important; left: 63% !important; }
-    &[data-day="5"] { top: 59.5% !important; left: 76% !important; }
-    &[data-day="6"] { top: 59.5% !important; left: 89% !important; }
-  }
-  
-  // 4週目
-  &[data-week="3"] {
-    &[data-day="0"] { top: 68.5% !important; left: 11% !important; }
-    &[data-day="1"] { top: 68.5% !important; left: 24% !important; }
-    &[data-day="2"] { top: 68.5% !important; left: 37% !important; }
-    &[data-day="3"] { top: 68.5% !important; left: 50% !important; }
-    &[data-day="4"] { top: 68.5% !important; left: 63% !important; }
-    &[data-day="5"] { top: 68.5% !important; left: 76% !important; }
-    &[data-day="6"] { top: 68.5% !important; left: 89% !important; }
-  }
-  
-  // 5週目
-  &[data-week="4"] {
-    &[data-day="0"] { top: 76% !important; left: 11% !important; }
-    &[data-day="1"] { top: 76% !important; left: 24% !important; }
-    &[data-day="2"] { top: 76% !important; left: 37% !important; }
-    &[data-day="3"] { top: 76% !important; left: 50% !important; }
-    &[data-day="4"] { top: 76% !important; left: 63% !important; }
-    &[data-day="5"] { top: 76% !important; left: 76% !important; }
-    &[data-day="6"] { top: 76% !important; left: 89% !important; }
-  }
-  
-  // 位置調整（中央寄せ）
-  transform: translate(-50%, -50%);
-}
-
-// 日付数字表示（常時表示）- さらに大きく
-.date-number {
-  font-size: 36px;
-  font-weight: bold;
-  color: white !important;
-  z-index: 4;
-  text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.9);
-}
-
-// スタンプオーバーレイ（押印済みの日のみ）
-.stamp-overlay-image {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  z-index: 5;
-  animation: stampAppear 0.4s cubic-bezier(0.68, -0.55, 0.265, 1.55);
-}
-
-.participation-stamp {
-  font-size: 28px;
-  font-weight: 900;
-  color: #dc3545 !important;
-  text-shadow: 
-    1px 1px 0px rgba(255, 255, 255, 0.9),
-    2px 2px 4px rgba(0, 0, 0, 0.6);
-  opacity: 0.95;
-  border: 2px solid #dc3545;
-  border-radius: 50%;
-  width: 36px;
-  height: 36px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: rgba(255, 255, 255, 0.15);
-  backdrop-filter: blur(1px);
-  box-shadow: 0 2px 8px rgba(220, 53, 69, 0.4);
-}
-
-@keyframes stampAppear {
-  0% {
-    opacity: 0;
-    transform: translate(-50%, -50%) scale(0) rotate(-10deg);
-  }
-  50% {
-    transform: translate(-50%, -50%) scale(1.2) rotate(5deg);
-  }
-  100% {
-    opacity: 0.9;
-    transform: translate(-50%, -50%) scale(1) rotate(0deg);
-  }
-}
 
 
 
-// カレンダー日付の状態別スタイル
-.stamp-position {
-  &.other-month {
-    opacity: 0.4;
-    
-    .date-number {
-      color: #95a5a6 !important;
-    }
-  }
-}
+
+
 
 // 統計情報サイドバーのスタイル
 .statistics-sidebar {
@@ -332,12 +131,6 @@
     max-width: 450px !important;
   }
   
-  // スタンプスタイルのタブレット調整
-  .participation-stamp {
-    font-size: 24px;
-    width: 32px;
-    height: 32px;
-  }
   
   // タブレット以下で統計情報を横並びに変更
   .statistics-sidebar {
@@ -370,12 +163,6 @@
     max-width: 400px !important;
   }
   
-  // スタンプスタイルのモバイル調整
-  .participation-stamp {
-    font-size: 18px;
-    width: 26px;
-    height: 26px;
-  }
   
   // モバイルで統計情報を横並びのまま維持
   .statistics-sidebar {
@@ -414,26 +201,7 @@
   }
 }
 
-@keyframes stampBounce {
-  0% { transform: scale(0); }
-  50% { transform: scale(1.2); }
-  100% { transform: scale(1); }
-}
 
-// ホバー効果とアニメーション
-.stamp-position {
-  transition: all 0.3s ease;
-  
-  
-  
-  .date-number {
-    transition: all 0.3s ease;
-  }
-  
-  .stamp-time {
-    animation: fadeInUp 0.8s ease-out 0.3s both;
-  }
-}
 
 // 月間ナビゲーションボタンのホバー効果
 .month-navigation {
@@ -471,33 +239,6 @@
     max-width: 350px !important;
   }
   
-  .date-number {
-    font-size: 28px !important;
-  }
-  
-  .participation-stamp {
-    font-size: 16px;
-    width: 22px;
-    height: 22px;
-  }
-  
-  // 月・年・ユーザー名オーバーレイのモバイル調整
-  .calendar-year {
-    font-size: 0.9rem;
-  }
-  
-  .calendar-month-number {
-    font-size: 1.4rem;
-  }
-  
-  .calendar-month-text {
-    font-size: 0.9rem;
-  }
-  
-  .calendar-user-name {
-    font-size: 0.7rem;
-    max-width: 100px;
-  }
   
   // 月間ナビゲーションのモバイル調整
   .month-navigation {


### PR DESCRIPTION
# 概要

Radio-Calisthenicsプロジェクトのカレンダー機能リファクタリング第1段階として、
**CSS完全クリーンアップ**を実施しました。

これにより、既存のカレンダー関連スタイルをすべて削除し、
今後の実装に向けてクリーンな状態を作り出しました。

## 📋 実装内容詳細

### 削除したCSS要素
- **日付表示関連CSS**: フォントサイズ、色、影などのスタイル
- **スタンプ位置座標CSS**: 週・日ごとの絶対位置指定
- **スタンプオーバーレイCSS**: スタンプ画像・アニメーション
- **カレンダー状態別スタイル**: 前後月の日付スタイル
- **不要なアニメーション**: stampBounce等

### 保持したCSS要素
- **基本的なカード画像スタイル**: stamp-card-container等
- **統計情報サイドバー**: 既存機能のスタイル
- **Bootstrapベース**: 基本的なUIフレームワーク

## 📊 変更統計
- **削除行数**: 約250行のCSS
- **ファイル数**: 1ファイル（application.scss）
- **影響範囲**: カレンダー表示部分のみ

## ⚠️ 影響範囲・懸念点

### 一時的な表示崩れ
- カレンダーの日付表示が一時的に崩れます
- スタンプ機能は次のフェーズで削除予定
- 統計情報等の既存機能への影響なし

## ✅ 動作確認

- [x] CSSの構文エラーなし
- [x] Rails アプリケーションの起動確認
- [x] 統計情報表示の正常動作確認

## 🎯 次のステップ

**Phase 2**: スタンプ機能の完全削除
- HTMLからスタンプ関連要素を削除
- 一時的な機能無効化

---

## 🤖 実装プロセス

このPRは**カレンダー機能リファクタリング計画**の第1段階です：
1. CSS完全クリーンアップ（本PR）
2. スタンプ機能削除
3. ImageMagick導入
4. カレンダーヘッダー実装
5. カレンダー日付表示実装

---

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>