### PR TITLE
feat: スタンプカードページのレイアウト改善

### DIFF
--- a/app/views/stamp_cards/index.html.erb
+++ b/app/views/stamp_cards/index.html.erb
@@ -2,6 +2,27 @@
 
 <div class="container mt-4">
 
+  <!-- 今日のスタンプ -->
+  <% if @monthly_stats[:can_stamp_today] %>
+    <div class="row mb-4">
+      <div class="col-12">
+        <div class="card border-primary">
+          <div class="card-body text-center">
+            <h5 class="card-title text-primary">今日のラジオ体操はいかがでしたか？</h5>
+            <p class="card-text">今日のスタンプを押して記録を残しましょう！</p>
+            <%= form_with model: StampCard.new, url: stamp_cards_path, class: "d-inline" do |form| %>
+              <%= form.hidden_field :date, value: Date.current %>
+              <%= form.submit "📅 今日のスタンプを押す", 
+                              class: "btn btn-primary btn-lg",
+                              "aria-label": "今日の日付（#{Date.current.strftime('%Y年%m月%d日')}）にスタンプを記録",
+                              data: { confirm: "今日のスタンプを押しますか？" } %>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    </div>
+  <% end %>
+
   <!-- 月間ナビゲーション -->
   <div class="row mb-4">
     <div class="col-12">
@@ -48,7 +69,7 @@
   <div class="row mb-4">
     <!-- ラジオ体操カード表示（左側） -->
     <div class="col-lg-7 mb-4">
-      <div class="card h-100">
+      <div class="card" style="height: 1000px;">
         <div class="card-header">
           <h5 class="mb-0">📅 ラジオ体操カード</h5>
         </div>
@@ -78,11 +99,11 @@
 
     <!-- 月間統計サマリー（右側） -->
     <div class="col-lg-5">
-      <div class="card h-100">
+      <div class="card" style="height: 1000px;">
         <div class="card-header">
           <h5 class="mb-0">📊 あなたの記録</h5>
         </div>
-        <div class="card-body">
+        <div class="card-body" style="overflow-y: auto;">
           <div class="d-flex flex-column gap-2">
             <!-- 基本統計 -->
             <div class="text-center p-3 border rounded bg-light">
@@ -153,27 +174,6 @@
       </div>
     </div>
   </div>
-
-  <!-- 今日のスタンプ -->
-  <% if @monthly_stats[:can_stamp_today] %>
-    <div class="row mb-4">
-      <div class="col-12">
-        <div class="card border-primary">
-          <div class="card-body text-center">
-            <h5 class="card-title text-primary">今日のラジオ体操はいかがでしたか？</h5>
-            <p class="card-text">今日のスタンプを押して記録を残しましょう！</p>
-            <%= form_with model: StampCard.new, url: stamp_cards_path, class: "d-inline" do |form| %>
-              <%= form.hidden_field :date, value: Date.current %>
-              <%= form.submit "📅 今日のスタンプを押す", 
-                              class: "btn btn-primary btn-lg",
-                              "aria-label": "今日の日付（#{Date.current.strftime('%Y年%m月%d日')}）にスタンプを記録",
-                              data: { confirm: "今日のスタンプを押しますか？" } %>
-            <% end %>
-          </div>
-        </div>
-      </div>
-    </div>
-  <% end %>
 
 </div>
 


### PR DESCRIPTION
## Summary
- 「今日のスタンプ」セクションをページ最上部に移動し、ユーザーのアクセシビリティを向上
- 左右のカードの高さを1000pxで統一し、視覚的な一貫性を確保
- 右側「あなたの記録」カードにスクロール機能を追加

## Test plan
- [x] テストが全て成功することを確認 (63 examples, 0 failures)
- [x] レスポンシブデザインの動作確認
- [x] スタンプ押下機能の動作確認
- [x] 左右カードの高さが統一されていることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)