### PR TITLE
fix: 管理者メニューのドロップダウン動作とAdmin機能エラーを修正

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -2,7 +2,6 @@ class Admin::UsersController < Admin::BaseController
   def index
     @users = User.includes(:stamp_cards)
                  .order(:created_at)
-                 .page(params[:page])
 
     @users_with_stats = @users.map do |user|
       {
@@ -28,7 +27,7 @@ class Admin::UsersController < Admin::BaseController
       {
         month: month,
         count: user.stamp_cards.where(
-          date: month.beginning_of_month..month.end_of_month
+          date: month..month.end_of_month
         ).count
       }
     end.reverse

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,7 +1,7 @@
 // Configure your import map in config/importmap.rb
 import "@hotwired/turbo-rails"
 import "controllers"
-import "bootstrap"
+import * as bootstrap from "bootstrap"
 
 // Initialize Bootstrap when DOM content is loaded
 document.addEventListener("DOMContentLoaded", function() {
@@ -16,6 +16,12 @@ document.addEventListener("DOMContentLoaded", function() {
   var popoverList = popoverTriggerList.map(function (popoverTriggerEl) {
     return new bootstrap.Popover(popoverTriggerEl)
   })
+
+  // Bootstrap dropdowns initialization
+  var dropdownTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="dropdown"]'))
+  var dropdownList = dropdownTriggerList.map(function (dropdownTriggerEl) {
+    return new bootstrap.Dropdown(dropdownTriggerEl)
+  })
 })
 
 // Turbo compatibility for Bootstrap
@@ -29,5 +35,10 @@ document.addEventListener("turbo:load", function() {
   var popoverTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="popover"]'))
   var popoverList = popoverTriggerList.map(function (popoverTriggerEl) {
     return new bootstrap.Popover(popoverTriggerEl)
+  })
+
+  var dropdownTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="dropdown"]'))
+  var dropdownList = dropdownTriggerList.map(function (dropdownTriggerEl) {
+    return new bootstrap.Dropdown(dropdownTriggerEl)
   })
 })

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -39,11 +39,7 @@
             
             <dt class="col-sm-5">最終ログイン:</dt>
             <dd class="col-sm-7">
-              <% if @user.current_sign_in_at %>
-                <%= @user.current_sign_in_at.strftime("%Y年%m月%d日 %H:%M") %>
-              <% else %>
-                <span class="text-muted">ログイン記録なし</span>
-              <% end %>
+              <span class="text-muted">ログイン追跡機能は無効です</span>
             </dd>
           </dl>
         </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,10 +23,10 @@
             <%= link_to "🏆 バッジ", badges_path, class: "nav-link" %>
             <% if current_user.admin? %>
               <div class="nav-item dropdown">
-                <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown">
+                <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false" id="adminDropdown">
                   🎯 管理者メニュー
                 </a>
-                <ul class="dropdown-menu">
+                <ul class="dropdown-menu" aria-labelledby="adminDropdown">
                   <li><%= link_to "📊 ダッシュボード", admin_root_path, class: "dropdown-item" %></li>
                   <li><%= link_to "👥 ユーザー管理", admin_users_path, class: "dropdown-item" %></li>
                   <li><%= link_to "⚙️ 設定", admin_settings_path, class: "dropdown-item" %></li>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -1,8 +1,8 @@
 # Pin npm packages by running ./bin/importmap
 
 pin "application"
-pin "bootstrap", to: "https://ga.jspm.io/npm:bootstrap@5.2.3/dist/js/bootstrap.esm.js"
-pin "@popperjs/core", to: "https://ga.jspm.io/npm:@popperjs/core@2.11.6/lib/index.js"
+pin "bootstrap", to: "https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.esm.min.js"
+pin "@popperjs/core", to: "https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.6/dist/esm/index.js"
 
 pin_all_from "app/javascript/controllers", under: "controllers"
 pin "@hotwired/turbo-rails", to: "turbo.min.js"


### PR DESCRIPTION
## Summary
管理者メニューのドロップダウンが動作しない問題と、Admin機能の各種NoMethodErrorを修正しました。

## 修正内容

### 🎯 管理者メニューのドロップダウン修正
- **Bootstrap import問題**: `import * as bootstrap from "bootstrap"` に変更
- **PopperJS process未定義エラー**: importmapのCDNをjsDelivr経由に変更
- **HTML属性不足**: `aria-expanded`, `id`, `aria-labelledby` 属性を追加
- **JavaScript初期化**: ドロップダウン要素の適切な初期化を追加

### 👥 Admin::UsersController修正
- **indexアクション**: 未定義の`.page()`メソッド（Kaminari）を削除
- **showアクション**: `generate_monthly_stats`の重複`beginning_of_month`を修正
- **show.html.erb**: 存在しない`current_sign_in_at`フィールドを適切な表示に変更

## 技術詳細

### Bootstrap 5.2対応
```javascript
// 修正前
import "bootstrap"

// 修正後
import * as bootstrap from "bootstrap"
```

### PopperJS CDN修正
```ruby
# 修正前（jspm.io - process未定義エラー）
pin "@popperjs/core", to: "https://ga.jspm.io/npm:@popperjs/core@2.11.6/lib/index.js"

# 修正後（jsdelivr - ブラウザー互換）
pin "@popperjs/core", to: "https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.6/dist/esm/index.js"
```

### HTML属性追加
```erb
<\!-- 修正前 -->
<a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown">

<\!-- 修正後 -->
<a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false" id="adminDropdown">
```

## Test plan
- [x] 管理者メニューのドロップダウンが正常に動作する
- [x] ユーザー管理一覧ページが表示される
- [x] ユーザー詳細ページが表示される
- [x] 管理者ダッシュボードが正常に動作する
- [x] 設定ページが正常に動作する

## 修正されたファイル
- `app/views/layouts/application.html.erb` - ドロップダウンHTML属性
- `app/javascript/application.js` - Bootstrap import・初期化
- `config/importmap.rb` - CDN URL変更
- `app/controllers/admin/users_controller.rb` - メソッドエラー修正
- `app/views/admin/users/show.html.erb` - 存在しないフィールド修正

🤖 Generated with [Claude Code](https://claude.ai/code)