### PR TITLE
fix: スタンプカードレイアウト調整 - 新マス数対応

### DIFF
--- a/app/views/stamp_cards/index.html.erb
+++ b/app/views/stamp_cards/index.html.erb
@@ -82,9 +82,9 @@
               <!-- カレンダーグリッドのスタンプ表示 -->
               <% 
                 # カレンダーの開始位置とグリッドサイズ
-                grid_start_x = 70
-                grid_start_y = 200
-                cell_width = 95
+                grid_start_x = 72
+                grid_start_y = 110
+                cell_width = 94
                 cell_height = 95
               %>
               

--- a/app/views/stamp_cards/index.html.erb
+++ b/app/views/stamp_cards/index.html.erb
@@ -176,8 +176,8 @@
                       <!-- 1つ目の日付のスタンプ -->
                       <% if date1_stamped %>
                         <image href="<%= asset_path('stamp_completed.png') %>" 
-                               x="<%= x_pos - 50 %>" 
-                               y="<%= y_pos - 63 %>" 
+                               x="<%= x_pos - 33 %>" 
+                               y="<%= y_pos - 90 %>" 
                                width="50" 
                                height="50"
                                opacity="0.8"
@@ -190,8 +190,8 @@
                       <!-- 2つ目の日付のスタンプ -->
                       <% if date2_stamped %>
                         <image href="<%= asset_path('stamp_completed.png') %>" 
-                               x="<%= x_pos %>" 
-                               y="<%= y_pos - 27 %>" 
+                               x="<%= x_pos + 17 %>" 
+                               y="<%= y_pos - 90 %>" 
                                width="50" 
                                height="50"
                                opacity="0.8"
@@ -204,8 +204,8 @@
                       <!-- 単一日付のスタンプ -->
                       <% if day_data[:stamped] %>
                         <image href="<%= asset_path('stamp_completed.png') %>" 
-                               x="<%= x_pos - 40 %>" 
-                               y="<%= y_pos - 60 %>" 
+                               x="<%= x_pos - 18 %>" 
+                               y="<%= y_pos - 90 %>" 
                                width="80" 
                                height="80"
                                opacity="0.8"

--- a/app/views/stamp_cards/index.html.erb
+++ b/app/views/stamp_cards/index.html.erb
@@ -70,7 +70,7 @@
               </text>
               
               <!-- 月の数字 -->
-              <text x="120" y="110" 
+              <text x="120" y="-30" 
                     text-anchor="middle" 
                     font-family="Arial, sans-serif" 
                     font-size="72" 

--- a/app/views/stamp_cards/index.html.erb
+++ b/app/views/stamp_cards/index.html.erb
@@ -60,17 +60,17 @@
                  preserveAspectRatio="xMidYMid meet"
                  style="pointer-events: none;">
               <!-- ユーザー名表示 -->
-              <text x="460" y="-13" 
+              <text x="400" y="-45" 
                     text-anchor="start" 
                     font-family="Arial, sans-serif" 
-                    font-size="24" 
+                    font-size="42" 
                     font-weight="bold" 
                     fill="#2c3e50">
                 <%= current_user.email.split('@').first %>
               </text>
               
               <!-- 月の数字 -->
-              <text x="100" y="0" 
+              <text x="120" y="110" 
                     text-anchor="middle" 
                     font-family="Arial, sans-serif" 
                     font-size="72" 
@@ -82,10 +82,10 @@
               <!-- カレンダーグリッドのスタンプ表示 -->
               <% 
                 # カレンダーの開始位置とグリッドサイズ
-                grid_start_x = 45
-                grid_start_y = 180
-                cell_width = 101
-                cell_height = 100
+                grid_start_x = 70
+                grid_start_y = 200
+                cell_width = 95
+                cell_height = 95
               %>
               
               <!-- カレンダー日付とスタンプ -->


### PR DESCRIPTION
## Summary
スタンプカードのマス数変更に伴い、名前・月・日付・スタンプの位置を段階的に調整しました。

### 調整内容
- **名前位置**: x=400, y=-45, フォントサイズ42に調整
- **月位置**: x=120, y=-30に調整  
- **日付グリッド**: 開始位置(x=72, y=110)、セルサイズ(幅94, 高さ95)に調整
- **スタンプ位置**: 統一された右上配置に調整

### 修正前の問題
- スタンプカードのマス数変更により各要素の位置がずれていた
- 名前、月、日付、スタンプの配置が適切でなかった

### 修正後の改善
- 全ての要素が新しいカードレイアウトに適切に配置
- バランスの取れた美しいレイアウト
- スタンプと日付の位置関係が最適化

## Test plan
- [x] 名前表示位置の確認
- [x] 月表示位置の確認  
- [x] 日付グリッドの配置確認
- [x] スタンプ位置の確認
- [x] レスポンシブ表示の確認

🤖 Generated with [Claude Code](https://claude.ai/code)