### PR TITLE
fix: 月次統計ページのエラーを修正

### DIFF
--- a/app/views/statistics/monthly.html.erb
+++ b/app/views/statistics/monthly.html.erb
@@ -157,7 +157,7 @@
                       <% if day[:current_month] %>
                         <div class="day-number" style="font-weight: bold; font-size: 1.5rem; color: white; text-shadow: 1px 1px 2px rgba(0,0,0,0.3);"><%= day[:date].day %></div>
                         <% if day[:stamped] %>
-                          <%= image_tag "stamps/heart_stamp.svg", class: "stamp-image", alt: "参加済み", style: "width: 25px; height: 25px; margin-top: -5px; opacity: 0.9;" %>
+                          <%= image_tag "heart_stamp.svg", class: "stamp-image", alt: "参加済み", style: "width: 25px; height: 25px; margin-top: -5px; opacity: 0.9;" %>
                           <div class="stamp-time" style="position: absolute; bottom: 2px; font-size: 0.6rem; color: white; opacity: 0.8;">
                             <%= day[:stamped_time] %>
                           </div>
@@ -180,7 +180,7 @@
               <div class="d-flex justify-content-center gap-4 small">
                 <div>
                   <span class="badge bg-success">
-                    <%= image_tag "stamps/heart_stamp.svg", style: "width: 16px; height: 16px;", alt: "参加済み" %>
+                    <%= image_tag "heart_stamp.svg", style: "width: 16px; height: 16px;", alt: "参加済み" %>
                   </span> 
                   参加済み
                 </div>

--- a/app/views/statistics/monthly.html.erb
+++ b/app/views/statistics/monthly.html.erb
@@ -87,8 +87,18 @@
           </div>
           <h5 class="card-title">平均参加時刻</h5>
           <h2 class="text-info mb-0">
-            <% if @monthly_stats[:average_time] %>
-              <%= Time.new(2000, 1, 1, 0, @monthly_stats[:average_time].to_i).strftime("%H:%M") %>
+            <% if @monthly_stats[:average_time].present? && @monthly_stats[:average_time].is_a?(Numeric) %>
+              <% 
+                total_minutes = @monthly_stats[:average_time].to_i
+                hours = total_minutes / 60
+                minutes = total_minutes % 60
+                # 有効な時間範囲内であることを確認
+                if hours >= 0 && hours <= 23 && minutes >= 0 && minutes <= 59
+              %>
+                <%= sprintf("%02d:%02d", hours, minutes) %>
+              <% else %>
+                ---
+              <% end %>
             <% else %>
               ---
             <% end %>


### PR DESCRIPTION
## Summary
- 月次統計ページで発生していたArgumentErrorを修正
- SVGスタンプ画像のアセットパスエラーを解消
- 平均時間計算時の安全な型変換処理を実装

## Changes
### 1. ArgumentError修正 (eeadbdd)
- `detailed_monthly_statistics`メソッドで平均時間計算のnilチェックを追加
- 小数点を含む平均時間値の安全な整数変換処理を実装
- 有効な時間範囲内（0-1439分）の値制限を追加
- monthly.html.erbビューでTimeオブジェクト作成時の安全性を向上

### 2. AssetNotFoundエラー修正 (734e104)
- stamps/heart_stamp.svg → heart_stamp.svg にパスを修正
- アセットパイプラインに正しく存在するパスに変更
- Sprockets::Rails::Helper::AssetNotFoundエラーを解消

## Test plan
- [ ] 月次統計ページ (`/statistics/monthly`) にアクセスしてエラーが発生しないことを確認
- [ ] 平均時間が正しく表示されることを確認
- [ ] ハートスタンプのSVG画像が正しく表示されることを確認
- [ ] 各種エッジケース（データがない場合、平均時間が0の場合など）でエラーが発生しないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)