### PR TITLE
feat: アプリケーションのタイムゾーンを東京に設定

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -39,7 +39,7 @@ module RadioCalisthenics
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
-    # config.time_zone = "Central Time (US & Canada)"
+    config.time_zone = "Tokyo"
     # config.eager_load_paths << Rails.root.join("extras")
   end
 end


### PR DESCRIPTION
## Summary
- Railsアプリケーションのタイムゾーン設定を東京（JST）に変更
- これによりスタンプの記録や表示が日本時間基準になります

## 変更内容
- `config/application.rb` に `config.time_zone = "Tokyo"` を追加

## Test plan
- [x] RSpecテストがすべてパス（64 examples, 0 failures）
- [ ] ローカル環境でスタンプ機能の動作確認
- [ ] スタンプの時刻表示が日本時間になっていることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)