### PR TITLE
fix: Claude workflowに必要な権限を追加

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,6 +26,7 @@ jobs:
       pull-requests: read
       issues: read
       id-token: write
+      actions: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## 概要
Claude workflowでAPIキーが読み取れない問題を修正

## 変更内容
- `actions: read` 権限を追加
- GitHub Actions Secret読み取りエラーを解決

## 問題
```
Error: Environment variable validation failed:
  - Either ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN is required when using direct Anthropic API.
```

## 解決策
GitHub Actions workflowでSecretsを読み取るために必要な権限を追加

🤖 Generated with [Claude Code](https://claude.ai/code)