### PR TITLE
fix: Claude workflowのOAuth token設定を修正

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Run Claude PR Action
         uses: anthropics/claude-code-action@beta
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           timeout_minutes: "60"
 
   # This workflow provides additional CI support for Claude-generated code


### PR DESCRIPTION
## Summary
- Claude Code actionでANTHROPIC_API_KEYからCLAUDE_CODE_OAUTH_TOKENへの変更に対応
- GitHub Actions workflowでOAuth認証を正しく使用するよう修正

## Test plan
- [ ] Claude Code actionが正常に動作することを確認
- [ ] workflowが正しく実行されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)