### PR TITLE
feat: @claudeコメントによるワークフロー実行機能を追加

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -3,6 +3,8 @@ name: Claude Code
 on:
   issues:
     types: [labeled]
+  issue_comment:
+    types: [created]
   workflow_dispatch:
     inputs:
       issue_number:
@@ -12,7 +14,10 @@ on:
 
 jobs:
   claude-code:
-    if: github.event.label.name == 'claude-code' || github.event_name == 'workflow_dispatch'
+    if: |
+      github.event.label.name == 'claude-code' || 
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude'))
     runs-on: ubuntu-latest
     
     steps:
@@ -33,6 +38,8 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
             ISSUE_NUMBER="${{ github.event.inputs.issue_number }}"
+          elif [ "${{ github.event_name }}" == "issue_comment" ]; then
+            ISSUE_NUMBER="${{ github.event.issue.number }}"
           else
             ISSUE_NUMBER="${{ github.event.issue.number }}"
           fi


### PR DESCRIPTION
## 概要
IssueやPRで@claudeとコメントすることで、Claude Code GitHub Actionが自動実行されるように機能を追加しました。

## 追加された機能
- **@claudeメンション対応**: Issueコメントで@claudeと書くと自動実行
- **issue_commentイベント**: コメント作成時のトリガー追加
- **マルチトリガー対応**: ラベル、手動実行、コメントの3つの実行方法

## 使用方法
1. **ラベル**: Issueにラベルを付与
2. **手動実行**: GitHub Actionsから手動実行
3. **コメント**: Issueでとコメント ← 新機能

## 技術詳細
- イベントを追加
- でメンション検出
- 既存機能との互換性を保持

## テスト
- [ ] @claudeコメントでの自動実行確認
- [ ] 既存のラベル機能の動作確認
- [ ] 手動実行機能の動作確認