### PR TITLE
fix: Claude Codeブランチ競合問題を解決

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -62,6 +62,13 @@ jobs:
           git config user.email "claude-code[bot]@users.noreply.github.com"
           
           BRANCH_NAME="claude-code/issue-${{ steps.issue.outputs.number }}"
+          
+          # 既存のリモートブランチを削除（存在する場合）
+          git push origin --delete $BRANCH_NAME 2>/dev/null || echo "リモートブランチが存在しませんでした"
+          
+          # ローカルブランチを削除（存在する場合）
+          git branch -D $BRANCH_NAME 2>/dev/null || echo "ローカルブランチが存在しませんでした"
+          
           git checkout -b $BRANCH_NAME
           echo "branch_name=$BRANCH_NAME" >> $GITHUB_ENV
       


### PR DESCRIPTION
## 概要
Claude Code GitHub Actionのブランチ競合問題を解決しました。
既存のリモート・ローカルブランチを自動削除してから新しいブランチを作成します。

## 問題
- 同じブランチ名が既に存在していてプッシュに失敗
- 

## 修正内容
### ブランチクリーンアップ機能を追加
- **リモートブランチ削除**: 
- **ローカルブランチ削除**:   
- **エラー無視**: 存在しない場合のエラーを無視して安全に実行

## 期待される効果
- ✅ ブランチ名競合によるプッシュエラーを回避
- ✅ 確実なブランチ作成とプッシュを実現
- ✅ 既存ブランチの自動クリーンアップ
- ✅ PR作成の成功率向上

## 安全性
- 2>/dev/null でエラー出力を抑制
- || echo でエラー時の適切なメッセージ表示
- 存在しないブランチでも安全に実行

## テスト
- [ ] Issue #101での動作確認
- [ ] ブランチクリーンアップの確認
- [ ] PR作成の成功確認